### PR TITLE
Pass through value failure

### DIFF
--- a/src/result.ts
+++ b/src/result.ts
@@ -30,7 +30,7 @@ export type Failure = {
   /**
    * A key indicating the location at which validation failed.
    */
-  key: string;
+  key?: string;
 
   /**
    * The original value passed through so data inspection can be done after failure.

--- a/src/result.ts
+++ b/src/result.ts
@@ -36,7 +36,7 @@ export type Failure = {
    * The original value passed through so data inspection can be done after failure.
    * value is `any` here because its argument in `validate` is `any` type.
    */
-  value: any;
+  valueInvalidated: any;
 };
 
 /**

--- a/src/result.ts
+++ b/src/result.ts
@@ -31,6 +31,12 @@ export type Failure = {
    * A key indicating the location at which validation failed.
    */
   key: string;
+
+  /**
+   * The original value passed through so data inspection can be done after failure.
+   * value is `any` here because its argument in `validate` is `any` type.
+   */
+  value: any;
 };
 
 /**

--- a/src/result.ts
+++ b/src/result.ts
@@ -30,7 +30,7 @@ export type Failure = {
   /**
    * A key indicating the location at which validation failed.
    */
-  key: string;
+  key?: string;
 };
 
 /**

--- a/src/runtype.ts
+++ b/src/runtype.ts
@@ -117,7 +117,7 @@ export function create<A extends Runtype>(check: (x: {}) => Static<A>, A: any): 
       check(value);
       return { success: true, value };
     } catch ({ message, key }) {
-      return { success: false, message, key, value };
+      return { success: false, message, key, valueInvalidated: value };
     }
   }
 

--- a/src/runtype.ts
+++ b/src/runtype.ts
@@ -117,7 +117,7 @@ export function create<A extends Runtype>(check: (x: {}) => Static<A>, A: any): 
       check(value);
       return { success: true, value };
     } catch ({ message, key }) {
-      return { success: false, message, key };
+      return { success: false, message, key, value };
     }
   }
 


### PR DESCRIPTION
When validation fails, pass through the original `value` argument. Runtypes does give the message and key for the validation failure, however it does not (currently) pass through the original value argument, so there is not any introspection that can be done on it after failure without the original un-validated value. This is annoying because if one wants to do introspection after failure (e.g. null check) it would have to be done by passing in the runtype `Result` _and_ the original `any`/`unknown` value.

It would be dangerous to allow `Success` and `Failure` to both have a `value` key because then one could call `.value` on any type of result. IMO calling it `valueInvalidated` indicates that it does represent some sort of value but it should not be taken as checked data.